### PR TITLE
Coordinator must handle obsolete validation outcomes [SUBS-419]

### DIFF
--- a/validator-coordinator/src/main/java/uk/ac/ebi/subs/validator/coordinator/OutcomeDocumentService.java
+++ b/validator-coordinator/src/main/java/uk/ac/ebi/subs/validator/coordinator/OutcomeDocumentService.java
@@ -48,7 +48,11 @@ public class OutcomeDocumentService {
                     .collect(Collectors.toList());
 
             double max = Collections.max(doubleVersions);
-            return String.valueOf(max + 0.1);
+            String version = String.valueOf(max + 0.1);
+
+            deleteObsoleteValidationOutcomeResults(validationOutcomes);
+
+            return version;
         }
         return "1.0";
     }
@@ -69,4 +73,7 @@ public class OutcomeDocumentService {
         return outcomeDocument;
     }
 
+    private void deleteObsoleteValidationOutcomeResults(List<ValidationOutcome> validationOutcomes) {
+        repository.delete(validationOutcomes);
+    }
 }


### PR DESCRIPTION
Coordinator deletes obsolete validation outcome documents after defining new document version.
