### PR TITLE
Aggregator handles missing validation outcome documents [SUBS-420]

### DIFF
--- a/validator-aggregator/src/main/java/uk/ac/ebi/subs/validator/aggregator/AggregatorListener.java
+++ b/validator-aggregator/src/main/java/uk/ac/ebi/subs/validator/aggregator/AggregatorListener.java
@@ -43,7 +43,7 @@ public class AggregatorListener {
         if(success) {
             sendOutcomeDocumentUpdate(validationOutcome);
         } else {
-            logger.info("Ignoring validation results for older version.");
+            logger.info("Ignoring obsolete validation results.");
         }
     }
 

--- a/validator-aggregator/src/main/java/uk/ac/ebi/subs/validator/aggregator/OutcomeDocumentService.java
+++ b/validator-aggregator/src/main/java/uk/ac/ebi/subs/validator/aggregator/OutcomeDocumentService.java
@@ -20,11 +20,13 @@ public class OutcomeDocumentService {
     public boolean updateValidationOutcome(EntityValidationOutcome validationOutcome) {
         ValidationOutcome outcome = repository.findOne(validationOutcome.getOutcomeDocumentUUID());
 
-        if(isLatestVersion(outcome.getSubmissionId(), outcome.getEntityUuid(), Double.valueOf(outcome.getVersion()))) {
-            outcome.getValidationResults().add(validationOutcome);
-            outcome.getExpectedOutcomes().put(validationOutcome.getArchive(), true);
-            repository.save(outcome);
-            return true;
+        if (outcome != null) { // An obsolete document may already been deleted.
+            if (isLatestVersion(outcome.getSubmissionId(), outcome.getEntityUuid(), Double.valueOf(outcome.getVersion()))) {
+                outcome.getValidationResults().add(validationOutcome);
+                outcome.getExpectedOutcomes().put(validationOutcome.getArchive(), true);
+                repository.save(outcome);
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
The aggregator checks for a `null` result to the query to MongoDB. If this happens, it means that document is no longer in the database and has been deleted by the _Coordinator_ after being considered obsolete. The aggregator will ignore the received `EntityValidationOutcome`.